### PR TITLE
Update dependencies of Kotlin projects

### DIFF
--- a/kotlin/add-interactive-ui-to-messages/build.gradle.kts
+++ b/kotlin/add-interactive-ui-to-messages/build.gradle.kts
@@ -1,16 +1,17 @@
-val ktor_version: String by project
-val kotlin_version: String by project
-val logback_version: String by project
-val space_sdk_version: String by project
-val jackson_version: String by project
+val ktorVersion: String by project
+val kotlinVersion: String by project
+val logbackVersion: String by project
+val jacksonVersion: String by project
+val spaceSdkVersion: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.21"
 }
 
 group = "com.example"
 version = "0.0.1"
+
 application {
     mainClass.set("com.example.ApplicationKt")
 
@@ -24,12 +25,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-jetty-jvm:$ktorVersion")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    implementation("org.jetbrains:space-sdk-jvm:$space_sdk_version")
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("org.jetbrains:space-sdk-jvm:$spaceSdkVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
 }

--- a/kotlin/add-interactive-ui-to-messages/gradle.properties
+++ b/kotlin/add-interactive-ui-to-messages/gradle.properties
@@ -1,10 +1,11 @@
-ktor_version=2.0.3
-kotlin_version=1.7.10
-logback_version=1.2.3
-jackson_version=2.13.3
-kotlin.code.style=official
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+jacksonVersion=2.14.1
 
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-space_sdk_version=106390-beta
+spaceSdkVersion=145856-beta
+
+kotlin.code.style=official

--- a/kotlin/add-interactive-ui-to-messages/gradle.properties
+++ b/kotlin/add-interactive-ui-to-messages/gradle.properties
@@ -6,6 +6,6 @@ jacksonVersion=2.14.1
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=145856-beta
+spaceSdkVersion=146949-beta
 
 kotlin.code.style=official

--- a/kotlin/add-interactive-ui-to-messages/src/main/kotlin/org/remindme/Application.kt
+++ b/kotlin/add-interactive-ui-to-messages/src/main/kotlin/org/remindme/Application.kt
@@ -3,7 +3,7 @@ package org.remindme
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.ktor.server.engine.*
-import io.ktor.server.netty.*
+import io.ktor.server.jetty.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -12,7 +12,7 @@ fun main() {
         log.error("Please specify application credentials in src/main/resources/application.conf")
         return
     }
-    embeddedServer(Netty, port = 8080) {
+    embeddedServer(Jetty, port = 8080) {
         configureRouting()
     }.start(wait = true)
 }

--- a/kotlin/app-homepage-react/build.gradle.kts
+++ b/kotlin/app-homepage-react/build.gradle.kts
@@ -9,17 +9,18 @@ val hikariVersion: String by project
 val postgresqlDriverVersion: String by project
 val nimbusVersion: String by project
 val kotlinxSerializationVersion: String by project
+val jacksonVersion: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.7.0"
-    kotlin("plugin.serialization") version "1.7.0"
+    kotlin("jvm") version "1.7.21"
+    kotlin("plugin.serialization") version "1.7.21"
     id("docker-compose")
-    id("com.github.node-gradle.node") version "3.4.0"
+    id("com.github.node-gradle.node") version "3.5.0"
 }
 
 node {
-    version.set("16.15.1")
+    version.set("18.12.1")
     download.set(true)
 }
 
@@ -42,6 +43,9 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
     implementation("org.jetbrains:space-sdk-jvm:$spaceSdkVersion")
+    // Include jackson databinding to override transitive vulnerable version 2.13.1
+    // TODO Remove once Space SDK updates dependency
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
@@ -72,9 +76,9 @@ sourceSets {
 }
 
 dockerCompose {
-    projectName = "space-events"
-    removeContainers = false
-    removeVolumes = false
+    setProjectName("space-events")
+    removeContainers.set(false)
+    removeVolumes.set(false)
 }
 
 tasks.register("clientNpmInstall", NpmTask::class) {

--- a/kotlin/app-homepage-react/gradle.properties
+++ b/kotlin/app-homepage-react/gradle.properties
@@ -1,15 +1,16 @@
-ktorVersion=2.0.3
-kotlinVersion=1.7.10
-logbackVersion=1.2.3
-exposedVersion=0.36.2
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+exposedVersion=0.40.1
 hikariVersion=5.0.1
-postgresqlDriverVersion=42.3.6
-nimbusVersion=9.15.2
-kotlinxSerializationVersion=1.3.3
+postgresqlDriverVersion=42.5.1
+nimbusVersion=9.25.6
+kotlinxSerializationVersion=1.4.1
+jacksonVersion=2.14.1
 
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=106390-beta
+spaceSdkVersion=145856-beta
 
 kotlin.code.style=official

--- a/kotlin/app-homepage-react/gradle.properties
+++ b/kotlin/app-homepage-react/gradle.properties
@@ -11,6 +11,6 @@ jacksonVersion=2.14.1
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=145856-beta
+spaceSdkVersion=146949-beta
 
 kotlin.code.style=official

--- a/kotlin/app-homepage-react/settings.gradle.kts
+++ b/kotlin/app-homepage-react/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "docker-compose") {
-                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.14.0")
+                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.16.11")
             }
         }
     }

--- a/kotlin/app-homepage-react/src/main/kotlin/org/homepage/AppInstanceStorage.kt
+++ b/kotlin/app-homepage-react/src/main/kotlin/org/homepage/AppInstanceStorage.kt
@@ -1,6 +1,8 @@
 package org.homepage
 
 import org.homepage.db.AppInstallation
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.replace
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -30,5 +32,9 @@ object AppInstanceStorage : SpaceAppInstanceStorage {
                 it[serverUrl] = appInstance.spaceServer.serverUrl
             }
         }
+    }
+
+    override suspend fun removeAppInstance(clientId: String): Unit = transaction {
+        AppInstallation.deleteWhere { AppInstallation.clientId.eq(clientId) }
     }
 }

--- a/kotlin/app-homepage-react/src/main/kotlin/org/homepage/services/AppHasPermissionsService.kt
+++ b/kotlin/app-homepage-react/src/main/kotlin/org/homepage/services/AppHasPermissionsService.kt
@@ -4,18 +4,19 @@ import org.homepage.appSpaceClient
 import space.jetbrains.api.runtime.resources.permissions
 import space.jetbrains.api.runtime.types.ApplicationIdentifier
 import space.jetbrains.api.runtime.types.GlobalPermissionTarget
+import space.jetbrains.api.runtime.types.PermissionIdentifier
 import space.jetbrains.api.runtime.types.PrincipalIn
 
 class AppHasPermissionsService(private val spaceTokenInfo: SpaceTokenInfo) {
     suspend fun appHasPermissions(): AppHasPermissionsResponse {
         val hasViewChannelPermissions = spaceTokenInfo.appSpaceClient().permissions.checkPermission(
             principal = PrincipalIn.Application(ApplicationIdentifier.Me),
-            "Channel.ViewChannel",
+            uniqueRightCode = PermissionIdentifier.ViewChannelInfo,
             target = GlobalPermissionTarget
         )
         val hasPostMessagesPermissions = spaceTokenInfo.appSpaceClient().permissions.checkPermission(
             principal = PrincipalIn.Application(ApplicationIdentifier.Me),
-            "Channel.PostMessages",
+            uniqueRightCode = PermissionIdentifier.PostMessages,
             target = GlobalPermissionTarget
         )
 

--- a/kotlin/context-menu-extension/.gitignore
+++ b/kotlin/context-menu-extension/.gitignore
@@ -1,0 +1,3 @@
+**/.gradle/
+/.idea/
+**/build/

--- a/kotlin/context-menu-extension/build.gradle.kts
+++ b/kotlin/context-menu-extension/build.gradle.kts
@@ -7,9 +7,10 @@ val logbackVersion: String by project
 val exposedVersion: String by project
 val hikariVersion: String by project
 val postgresDriverVersion: String by project
+val jacksonVersion: String by project
 
 plugins {
-    kotlin("jvm") version "1.7.0"
+    kotlin("jvm") version "1.7.21"
     id("docker-compose")
     application
 }
@@ -32,6 +33,9 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
 
     implementation("org.jetbrains:space-sdk-jvm:$spaceSdkVersion")
+    // Include jackson databinding to override transitive vulnerable version 2.13.1
+    // TODO Remove once Space SDK updates dependency
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
@@ -46,15 +50,16 @@ dependencies {
 kotlin.sourceSets.all {
     languageSettings {
         optIn("kotlin.time.ExperimentalTime")
-        optIn("io.ktor.server.locations.KtorExperimentalLocationsAPI")
         optIn("space.jetbrains.api.ExperimentalSpaceSdkApi")
     }
 }
 
 dockerCompose {
-    projectName = "space-events"
-    removeContainers = false
-    removeVolumes = false
+    // Docker Compose configuration was broken and not fixed.
+    // See https://github.com/avast/gradle-docker-compose-plugin/issues/353
+    setProjectName("space-events")
+    removeContainers.set(false)
+    removeVolumes.set(false)
 }
 
 tasks {

--- a/kotlin/context-menu-extension/gradle.properties
+++ b/kotlin/context-menu-extension/gradle.properties
@@ -1,15 +1,14 @@
-ktorVersion=2.0.3
-kotlinVersion=1.7.10
-logbackVersion=1.2.3
-exposedVersion=0.36.2
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+exposedVersion=0.40.1
 hikariVersion=5.0.1
-postgresDriverVersion=42.3.6
-nimbusVersion=9.15.2
-kotlinxSerializationVersion=1.3.3
+postgresDriverVersion=42.5.1
+jacksonVersion=2.14.1
 
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=109501-beta
+spaceSdkVersion=145856-beta
 
 kotlin.code.style=official

--- a/kotlin/context-menu-extension/gradle.properties
+++ b/kotlin/context-menu-extension/gradle.properties
@@ -9,6 +9,6 @@ jacksonVersion=2.14.1
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=145856-beta
+spaceSdkVersion=146949-beta
 
 kotlin.code.style=official

--- a/kotlin/context-menu-extension/settings.gradle.kts
+++ b/kotlin/context-menu-extension/settings.gradle.kts
@@ -2,7 +2,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "docker-compose") {
-                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.14.0")
+                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.16.11")
             }
         }
     }

--- a/kotlin/context-menu-extension/src/main/kotlin/com/example/AppInstanceStorage.kt
+++ b/kotlin/context-menu-extension/src/main/kotlin/com/example/AppInstanceStorage.kt
@@ -1,6 +1,8 @@
 package com.example
 
 import com.example.db.AppInstallation
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.replace
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -30,5 +32,9 @@ object AppInstanceStorage : SpaceAppInstanceStorage {
                 it[serverUrl] = appInstance.spaceServer.serverUrl
             }
         }
+    }
+
+    override suspend fun removeAppInstance(clientId: String): Unit = transaction {
+        AppInstallation.deleteWhere { AppInstallation.clientId.eq(clientId) }
     }
 }

--- a/kotlin/context-menu-extension/src/main/kotlin/com/example/db/DbApi.kt
+++ b/kotlin/context-menu-extension/src/main/kotlin/com/example/db/DbApi.kt
@@ -5,11 +5,12 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.replace
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
+import space.jetbrains.api.runtime.PermissionScope
 import space.jetbrains.api.runtime.types.RefreshTokenPayload
 
 data class RefreshTokenAndScope(
     val refreshToken: String,
-    val scope: String
+    val scope: PermissionScope
 )
 
 fun findRefreshTokenData(clientIdParam: String, userIdParam: String) = transaction {
@@ -17,7 +18,7 @@ fun findRefreshTokenData(clientIdParam: String, userIdParam: String) = transacti
         slice(refreshToken, scope).select {
             clientIdAndUserMatch(clientIdParam, userIdParam)
         }
-            .map { RefreshTokenAndScope(it[refreshToken], it[scope]) }
+            .map { RefreshTokenAndScope(it[refreshToken], PermissionScope.fromString(it[scope])) }
             .firstOrNull()
     }
 }
@@ -38,7 +39,7 @@ fun saveRefreshTokenData(payload: RefreshTokenPayload) = transaction {
             it[clientId] = payload.clientId
             it[userId] = payload.userId
             it[refreshToken] = payload.refreshToken
-            it[scope] = payload.scope
+            it[scope] = payload.scope.toString()
         }
     }
 }

--- a/kotlin/context-menu-extension/src/main/kotlin/com/example/processing/MenuActionPayload.kt
+++ b/kotlin/context-menu-extension/src/main/kotlin/com/example/processing/MenuActionPayload.kt
@@ -1,9 +1,7 @@
 package com.example.processing
 
 import com.example.db.findRefreshTokenData
-import space.jetbrains.api.runtime.PermissionDeniedException
-import space.jetbrains.api.runtime.RefreshTokenRevokedException
-import space.jetbrains.api.runtime.SpaceClient
+import space.jetbrains.api.runtime.*
 import space.jetbrains.api.runtime.helpers.ProcessingScope
 import space.jetbrains.api.runtime.resources.checklists
 import space.jetbrains.api.runtime.resources.projects
@@ -41,8 +39,25 @@ private val permissionsRequest = AppUserActionExecutionResult.AuthCodeFlowRequir
      */
     listOf(
         AuthCodeFlowPermissionsRequest(
-            "global:Project.Issues.Create global:Project.Issues.View global:Project.Issues.Edit global:Project.View",
-            "create task sub-items"
+            scope = PermissionScope.build(
+                PermissionScopeElement(
+                    context = GlobalPermissionContextIdentifier,
+                    permission = PermissionIdentifier.CreateIssues
+                ),
+                PermissionScopeElement(
+                    context = GlobalPermissionContextIdentifier,
+                    permission = PermissionIdentifier.ViewIssues
+                ),
+                PermissionScopeElement(
+                    context = GlobalPermissionContextIdentifier,
+                    permission = PermissionIdentifier.UpdateIssues
+                ),
+                PermissionScopeElement(
+                    context = GlobalPermissionContextIdentifier,
+                    permission = PermissionIdentifier.ViewProjectDetails
+                )
+            ),
+            purpose = "create task sub-items"
         )
     )
 )

--- a/kotlin/create-a-chatbot/build.gradle.kts
+++ b/kotlin/create-a-chatbot/build.gradle.kts
@@ -1,12 +1,12 @@
-val ktor_version: String by project
-val kotlin_version: String by project
-val logback_version: String by project
-val space_sdk_version: String by project
-val jackson_version: String by project
+val ktorVersion: String by project
+val kotlinVersion: String by project
+val logbackVersion: String by project
+val spaceSdkVersion: String by project
+val jacksonVersion: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.21"
 }
 
 group = "com.example"
@@ -24,12 +24,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-jetty-jvm:$ktorVersion")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-    implementation("org.jetbrains:space-sdk-jvm:$space_sdk_version")
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("org.jetbrains:space-sdk-jvm:$spaceSdkVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
 }

--- a/kotlin/create-a-chatbot/gradle.properties
+++ b/kotlin/create-a-chatbot/gradle.properties
@@ -1,10 +1,11 @@
-ktor_version=2.0.3
-kotlin_version=1.7.10
-logback_version=1.2.3
-jackson_version=2.13.3
-kotlin.code.style=official
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+jacksonVersion=2.14.1
 
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-space_sdk_version=106390-beta
+spaceSdkVersion=145856-beta
+
+kotlin.code.style=official

--- a/kotlin/create-a-chatbot/gradle.properties
+++ b/kotlin/create-a-chatbot/gradle.properties
@@ -6,6 +6,6 @@ jacksonVersion=2.14.1
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=145856-beta
+spaceSdkVersion=146949-beta
 
 kotlin.code.style=official

--- a/kotlin/create-a-chatbot/src/main/kotlin/org/remindme/Application.kt
+++ b/kotlin/create-a-chatbot/src/main/kotlin/org/remindme/Application.kt
@@ -3,7 +3,7 @@ package org.remindme
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.ktor.server.engine.*
-import io.ktor.server.netty.*
+import io.ktor.server.jetty.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -13,7 +13,7 @@ fun main() {
         return
     }
 
-    embeddedServer(Netty, port = 8080) {
+    embeddedServer(Jetty, port = 8080) {
         configureRouting()
     }.start(wait = true)
 }

--- a/kotlin/slack-link-previews/build.gradle
+++ b/kotlin/slack-link-previews/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation "io.ktor:ktor-server-jetty:$ktorVersion"
     implementation "ch.qos.logback:logback-classic:$logbackVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "org.jetbrains:space-sdk-jvm:106390-beta"
+    implementation "org.jetbrains:space-sdk-jvm:$spaceSdkVersion"
     implementation "io.ktor:ktor-client-core:$ktorVersion"
     implementation "io.ktor:ktor-client-cio:$ktorVersion"
     implementation "com.slack.api:slack-api-client:$slackVersion"

--- a/kotlin/slack-link-previews/build.gradle
+++ b/kotlin/slack-link-previews/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.jetbrains.kotlin.jvm' version '1.7.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
 }
 
 group "com.linkpreviews"
@@ -13,12 +13,12 @@ repositories {
 }
 
 dependencies {
-    implementation "io.ktor:ktor-server-core:$ktor_version"
-    implementation "io.ktor:ktor-server-netty:$ktor_version"
-    implementation "ch.qos.logback:logback-classic:$logback_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0"
+    implementation "io.ktor:ktor-server-core:$ktorVersion"
+    implementation "io.ktor:ktor-server-jetty:$ktorVersion"
+    implementation "ch.qos.logback:logback-classic:$logbackVersion"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation "org.jetbrains:space-sdk-jvm:106390-beta"
-    implementation "io.ktor:ktor-client-core:$ktor_version"
-    implementation "io.ktor:ktor-client-cio:$ktor_version"
-    implementation "com.slack.api:slack-api-client:1.18.0"
+    implementation "io.ktor:ktor-client-core:$ktorVersion"
+    implementation "io.ktor:ktor-client-cio:$ktorVersion"
+    implementation "com.slack.api:slack-api-client:$slackVersion"
 }

--- a/kotlin/slack-link-previews/gradle.properties
+++ b/kotlin/slack-link-previews/gradle.properties
@@ -4,4 +4,9 @@ logbackVersion=1.4.5
 jacksonVersion=2.14.1
 slackVersion=1.27.2
 
+# Newer version of Space SDK may be available.
+# You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
+# and click "Set up dependency..."
+spaceSdkVersion=146949-beta
+
 kotlin.code.style=official

--- a/kotlin/slack-link-previews/gradle.properties
+++ b/kotlin/slack-link-previews/gradle.properties
@@ -1,4 +1,7 @@
-ktor_version=2.0.1
-kotlin_version=1.7.10
-logback_version=1.2.3
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+jacksonVersion=2.14.1
+slackVersion=1.27.2
+
 kotlin.code.style=official

--- a/kotlin/slack-link-previews/src/main/kotlin/com/linkpreviews/Application.kt
+++ b/kotlin/slack-link-previews/src/main/kotlin/com/linkpreviews/Application.kt
@@ -1,11 +1,11 @@
 package com.linkpreviews
 
 import io.ktor.server.engine.*
-import io.ktor.server.netty.*
+import io.ktor.server.jetty.*
 import com.linkpreviews.plugins.*
 
 fun main() {
-    embeddedServer(Netty, port = 8080, host = "0.0.0.0") {
+    embeddedServer(Jetty, port = 8080, host = "0.0.0.0") {
         configureRouting()
     }.start(wait = true)
 }

--- a/kotlin/slack-link-previews/src/main/kotlin/com/linkpreviews/CommandInit.kt
+++ b/kotlin/slack-link-previews/src/main/kotlin/com/linkpreviews/CommandInit.kt
@@ -8,11 +8,11 @@ suspend fun commandInit(spaceUserId: String) {
     spaceClient.applications.authorizations.authorizedRights.requestRights(
         ApplicationIdentifier.Me,
         GlobalPermissionContextIdentifier,
-        listOf("Unfurl.App.ProvideAttachment")
+        listOf(PermissionIdentifier.ProvideExternalUnfurlsAsAttachments)
     )
     spaceClient.applications.unfurls.domains.updateUnfurledDomains(listOf(SlackWorkspace.domain))
     spaceClient.chats.messages.sendMessage(
         recipient = MessageRecipient.Member(ProfileIdentifier.Id(spaceUserId)),
-        ChatMessage.Text("ok")
+        content = ChatMessage.Text("ok")
     )
 }

--- a/kotlin/space-events/.gitignore
+++ b/kotlin/space-events/.gitignore
@@ -1,0 +1,3 @@
+**/.gradle/
+/.idea/
+**/build/

--- a/kotlin/space-events/build.gradle.kts
+++ b/kotlin/space-events/build.gradle.kts
@@ -1,14 +1,15 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val space_sdk_version: String by project
-val ktor_version: String by project
-val logback_version: String by project
-val exposed_version: String by project
-val hikari_version: String by project
-val postgresql_driver_version: String by project
+val spaceSdkVersion: String by project
+val ktorVersion: String by project
+val logbackVersion: String by project
+val exposedVersion: String by project
+val hikariVersion: String by project
+val postgresqlDriverVersion: String by project
+val jacksonVersion: String by project
 
 plugins {
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.21"
     id("docker-compose")
     application
 }
@@ -22,30 +23,35 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-jetty-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-core:$ktorVersion")
+    implementation("io.ktor:ktor-server-jetty-jvm:$ktorVersion")
 
-    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
 
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
 
-    implementation("org.jetbrains:space-sdk-jvm:$space_sdk_version")
+    implementation("org.jetbrains:space-sdk-jvm:$spaceSdkVersion")
+    // Include jackson databinding to override transitive vulnerable version 2.13.1
+    // TODO Remove once Space SDK updates dependency
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
-    implementation("org.jetbrains.exposed:exposed-core:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-dao:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-java-time:$exposed_version")
-    implementation("com.zaxxer:HikariCP:$hikari_version")
-    implementation("org.postgresql:postgresql:$postgresql_driver_version")
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
+    implementation("com.zaxxer:HikariCP:$hikariVersion")
+    implementation("org.postgresql:postgresql:$postgresqlDriverVersion")
 
     testImplementation(kotlin("test"))
 }
 
 dockerCompose {
-    projectName = "space-events"
-    removeContainers = false
-    removeVolumes = false
+    // Docker Compose configuration was broken and not fixed.
+    // See https://github.com/avast/gradle-docker-compose-plugin/issues/353
+    setProjectName("space-events")
+    removeContainers.set(false)
+    removeVolumes.set(false)
 }
 
 tasks.test {

--- a/kotlin/space-events/gradle.properties
+++ b/kotlin/space-events/gradle.properties
@@ -9,6 +9,6 @@ jacksonVersion=2.14.1
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-spaceSdkVersion=145856-beta
+spaceSdkVersion=146949-beta
 
 kotlin.code.style=official

--- a/kotlin/space-events/gradle.properties
+++ b/kotlin/space-events/gradle.properties
@@ -1,13 +1,14 @@
-ktor_version=2.0.3
-kotlin_version=1.7.10
-logback_version=1.2.3
-exposed_version=0.36.2
-hikari_version=5.0.1
-postgresql_driver_version=42.3.6
+ktorVersion=2.2.1
+kotlinVersion=1.7.21
+logbackVersion=1.4.5
+exposedVersion=0.40.1
+hikariVersion=5.0.1
+postgresqlDriverVersion=42.5.1
+jacksonVersion=2.14.1
 
 # Newer version of Space SDK may be available.
 # You can find the current version in API Playground, "Code" section on the right, choose "Kotlin SDK"
 # and click "Set up dependency..."
-space_sdk_version=106390-beta
+spaceSdkVersion=145856-beta
 
 kotlin.code.style=official

--- a/kotlin/space-events/settings.gradle
+++ b/kotlin/space-events/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "docker-compose") {
-                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.14.0")
+                useModule("com.avast.gradle:gradle-docker-compose-plugin:0.16.11")
             }
         }
     }

--- a/kotlin/space-events/src/main/kotlin/org/webhooks/AppInstanceStorage.kt
+++ b/kotlin/space-events/src/main/kotlin/org/webhooks/AppInstanceStorage.kt
@@ -3,6 +3,8 @@
 
 package org.webhooks
 
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.replace
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -34,5 +36,9 @@ object AppInstanceStorage : SpaceAppInstanceStorage {
                 it[serverUrl] = appInstance.spaceServer.serverUrl
             }
         }
+    }
+
+    override suspend fun removeAppInstance(clientId: String): Unit = transaction {
+        AppInstallation.deleteWhere { AppInstallation.clientId.eq(clientId) }
     }
 }

--- a/kotlin/space-events/src/main/kotlin/org/webhooks/InitPayload.kt
+++ b/kotlin/space-events/src/main/kotlin/org/webhooks/InitPayload.kt
@@ -5,9 +5,7 @@ package org.webhooks
 import space.jetbrains.api.ExperimentalSpaceSdkApi
 import space.jetbrains.api.runtime.helpers.ProcessingScope
 import space.jetbrains.api.runtime.resources.applications
-import space.jetbrains.api.runtime.types.ApplicationIdentifier
-import space.jetbrains.api.runtime.types.CustomGenericSubscriptionIn
-import space.jetbrains.api.runtime.types.GlobalPermissionContextIdentifier
+import space.jetbrains.api.runtime.types.*
 
 @ExperimentalSpaceSdkApi
 suspend fun ProcessingScope.setupWebhooks() {
@@ -48,6 +46,6 @@ suspend fun ProcessingScope.requestPermissions() {
     spaceClient.applications.authorizations.authorizedRights.requestRights(
         application = ApplicationIdentifier.Me,
         contextIdentifier = GlobalPermissionContextIdentifier,
-        listOf("Profile.Memberships.View", "Team.View")
+        listOf(PermissionIdentifier.ViewMemberships, PermissionIdentifier.ViewTeams)
     )
 }


### PR DESCRIPTION
Most important updates / changes:
- Update Kotlin `1.7.10` to `1.7.21`
- Replace Netty with Jetty because of transient vulnerable dependency (see [CVE-2022-41915](https://devhub.checkmarx.com/cve-details/CVE-2022-41915/)
- Add jackson databinding dependency wherever necessary to override transient vulnerable dependencies in the latest Space SDK (jvm) (see [CVE-2020-36518](https://devhub.checkmarx.com/cve-details/CVE-2020-36518), [CVE-2022-42003](https://devhub.checkmarx.com/cve-details/CVE-2022-42003) and [CVE-2022-42004](https://devhub.checkmarx.com/cve-details/CVE-2022-42004))
- Rename version constants to suppress naming convention warning
- Update Space SDK version in all Kotlin projects to `146949-beta`